### PR TITLE
docs: add GitHub Pages deployment and professionalize README

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --clean
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
 # m-gpux
 
-A modern command-line toolkit for Modal workflows:
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
+[![CLI](https://img.shields.io/badge/interface-Typer%20%2B%20Rich-0ea5e9)](https://typer.tiangolo.com/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-22c55e)](https://puxhocdl.github.io/m-gpux/)
 
-- Manage multiple Modal profiles
-- Launch GPU workloads from an interactive hub
-- Track cost usage across accounts
+`m-gpux` is a professional CLI toolkit for Modal power users who need fast GPU access, multi-profile account control, and simple cost visibility.
 
-`m-gpux` is built with Typer + Rich for a smooth CLI UX inspired by popular tools.
+## Highlights
 
-## Why m-gpux
+- Interactive GPU hub for Jupyter, script execution, and web shell sessions
+- Multi-account profile management in one command namespace
+- Billing inspection per profile or across all configured accounts
+- Friendly terminal UX with rich tables, prompts, and guided flows
 
-- Fast setup for GPU sessions (Jupyter, script runner, web shell)
-- Multi-profile account management in one place
-- Billing visibility for one account or all configured profiles
-- Human-friendly command output with interactive prompts
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Core Commands](#core-commands)
+- [Documentation](#documentation)
+- [Architecture](#architecture)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
 
 ## Installation
 
 ### Requirements
 
 - Python 3.10+
-- A Modal account with `token_id` and `token_secret`
-- Modal CLI available in your shell (`modal` command)
+- Modal account credentials (`token_id`, `token_secret`)
+- Modal CLI in PATH (`modal` command)
 
 ### Install from source
 
@@ -33,31 +41,21 @@ pip install -e .
 
 ## Quick Start
 
-### 1) Add a profile
-
 ```bash
+# 1) Add your first profile
 m-gpux account add
-```
 
-### 2) Verify profiles
-
-```bash
+# 2) Check configured profiles
 m-gpux account list
-```
 
-### 3) Launch GPU hub
-
-```bash
+# 3) Launch the interactive GPU hub
 m-gpux hub
-```
 
-### 4) Check billing usage
-
-```bash
+# 4) Inspect 30-day usage across all accounts
 m-gpux billing usage --days 30 --all
 ```
 
-## Command Overview
+## Core Commands
 
 ### Global
 
@@ -66,7 +64,7 @@ m-gpux --help
 m-gpux info
 ```
 
-### Account commands
+### Profile Management
 
 ```bash
 m-gpux account list
@@ -75,77 +73,66 @@ m-gpux account switch <profile_name>
 m-gpux account remove <profile_name>
 ```
 
-### Billing commands
+### Billing
 
 ```bash
 m-gpux billing open
-m-gpux billing usage
 m-gpux billing usage --days 7
 m-gpux billing usage --account personal
 m-gpux billing usage --all
 ```
 
-### Compute hub
+### Interactive Hub
 
 ```bash
 m-gpux hub
 ```
 
-From the hub, choose:
+Hub actions:
 
-- Jupyter Lab on a selected GPU
-- Run a local Python script on a selected GPU
-- Interactive web-based Bash shell on a selected GPU
-
-## Configuration
-
-Profiles are stored locally in:
-
-- `~/.modal.toml`
-
-When multiple profiles exist, exactly one can be active. The `hub` workflow uses the active profile credentials.
-
-## Example Workflows
-
-### Run a script on A100
-
-1. Run `m-gpux hub`
-2. Select GPU `A100`
-3. Select action `Run a Python Script`
-4. Enter your script filename
-5. Confirm and execute generated `modal_runner.py`
-
-### Audit weekly cost across all profiles
-
-```bash
-m-gpux billing usage --days 7 --all
-```
+- Jupyter Lab on selected GPU
+- Run local Python script on selected GPU
+- Interactive web Bash shell on selected GPU
 
 ## Documentation
 
-Detailed docs are available in the GitHub `docs` section:
+- Website: https://puxhocdl.github.io/m-gpux/
+- Local docs index: [docs/index.md](docs/index.md)
+- Getting started: [docs/getting-started.md](docs/getting-started.md)
+- Commands: [docs/commands.md](docs/commands.md)
+- FAQ: [docs/faq.md](docs/faq.md)
 
-- [Documentation Home](docs/index.md)
-- [Getting Started](docs/getting-started.md)
-- [Command Reference](docs/commands.md)
-- [FAQ and Troubleshooting](docs/faq.md)
+## Architecture
+
+- `m_gpux/main.py`: CLI entrypoint and command registration
+- `m_gpux/commands/account.py`: profile CRUD and active profile switching
+- `m_gpux/commands/billing.py`: usage aggregation and billing dashboard links
+- `m_gpux/commands/hub.py`: guided GPU runtime launcher
+
+## Configuration
+
+Modal profiles are persisted in `~/.modal.toml`.
+
+If the active profile is removed, another existing profile is promoted automatically.
 
 ## Troubleshooting
 
 - `No configured Modal profiles found`
-	- Run `m-gpux account add` first.
+  - Run `m-gpux account add`.
 - `modal: command not found`
-	- Install Modal CLI and ensure it is available in your shell.
-- Script file not found in hub mode
-	- Check filename/path and run from the project directory containing your script.
+  - Install Modal CLI and ensure PATH is set correctly.
+- Script file does not exist in hub mode
+  - Run command from the script directory or provide the correct filename.
 
-## Development
+## Contributing
 
 ```bash
 pip install -e .
 python -m m_gpux.main --help
 ```
 
+Open PRs are welcome for UX polish, command improvements, and docs quality.
+
 ## License
 
-MIT (or project owner's preferred license).
+MIT

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,34 @@
 # m-gpux Documentation
 
-Welcome to the official documentation for `m-gpux`, a CLI-first toolkit for managing Modal accounts, GPU sessions, and billing visibility.
+Welcome to the official docs for `m-gpux`, a production-focused CLI for Modal GPU operations.
 
-## What you can do with m-gpux
+## What is m-gpux?
 
-- Manage multiple Modal profiles locally
-- Switch active profile instantly
-- Launch interactive GPU sessions from a guided hub
-- Monitor usage and costs per account or across all accounts
+`m-gpux` helps you run high-performance compute workflows from terminal-first commands:
 
-## Documentation map
+- Manage multiple Modal identities in one place
+- Launch GPU runtimes through a guided interactive hub
+- Track usage costs by account or across all profiles
 
-- [Getting Started](getting-started.md)
-- [Command Reference](commands.md)
-- [FAQ and Troubleshooting](faq.md)
+## Start Here
 
-## Project links
+- New user setup: [Getting Started](getting-started.md)
+- Full command list: [Command Reference](commands.md)
+- Common issues: [FAQ and Troubleshooting](faq.md)
 
-- [Repository Root](../README.md)
-- [Quick Start](getting-started.md#quick-start)
-- [Hub Workflow](commands.md#hub)
+## Common Workflows
+
+### Launch Jupyter on a GPU
+
+1. `m-gpux account add`
+2. `m-gpux hub`
+3. Select your GPU and choose Jupyter mode
+
+### Check weekly cost across all accounts
+
+`m-gpux billing usage --days 7 --all`
+
+## Links
+
+- Repository: [PuxHocDL/m-gpux](https://github.com/PuxHocDL/m-gpux)
+- Project README: [README](https://github.com/PuxHocDL/m-gpux/blob/main/README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name: m-gpux
+site_description: Professional CLI toolkit for Modal GPU workflows
+site_url: https://puxhocdl.github.io/m-gpux/
+repo_url: https://github.com/PuxHocDL/m-gpux
+repo_name: PuxHocDL/m-gpux
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Command Reference: commands.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
This pull request introduces major improvements to documentation and project onboarding for `m-gpux`. It adds a full documentation website powered by MkDocs Material, configures automated deployment to GitHub Pages, and significantly rewrites the `README.md` for clarity, professionalism, and easier navigation. The changes aim to provide a better developer experience and make it easier for new users to get started.

**Documentation infrastructure and deployment:**

* Adds a new `mkdocs.yml` configuration for a documentation site using the Material theme, with navigation and project metadata.
* Introduces a GitHub Actions workflow (`.github/workflows/deploy-pages.yml`) to build and deploy the documentation to GitHub Pages on every push to `main`.

**Content and onboarding improvements:**

* Major rewrite of `README.md`:
  - Adds project badges, clearer feature highlights, and a reorganized table of contents.
  - Streamlines installation and quick start instructions.
  - Clarifies command usage and architecture, and improves troubleshooting and contribution sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R58) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R67) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R138)
* Updates `docs/index.md` with a concise project overview, common workflows, and direct links to key documentation sections and the repository.