### PR TITLE
v1.0.4: add all GPU types (T4-B200+), container metrics, load probe c…

### DIFF
--- a/m_gpux/__init__.py
+++ b/m_gpux/__init__.py
@@ -1,3 +1,3 @@
 """m_gpux package."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/m_gpux/commands/_metrics_snippet.py
+++ b/m_gpux/commands/_metrics_snippet.py
@@ -1,0 +1,93 @@
+"""Metrics template code injected into generated Modal container scripts.
+
+The FUNCTIONS string is a raw string containing Python code that will be
+inserted into generated scripts via str.replace(). Raw string ensures
+escape sequences like \\n and \\t remain as literal two-character sequences,
+which is exactly what we need in the generated Python files.
+"""
+
+FUNCTIONS = r'''
+def _print_metrics():
+    import subprocess as _sp, os as _os
+    print()
+    print("=" * 65)
+    print("  CONTAINER HARDWARE METRICS")
+    print("=" * 65)
+    try:
+        r = _sp.run(["nvidia-smi",
+            "--query-gpu=name,memory.total,memory.used,memory.free,utilization.gpu,"
+            "utilization.memory,temperature.gpu,power.draw,power.limit,driver_version",
+            "--format=csv,noheader,nounits"], capture_output=True, text=True, timeout=10)
+        if r.returncode == 0:
+            for i, line in enumerate(r.stdout.strip().split("\n")):
+                p = [x.strip() for x in line.split(",")]
+                if len(p) >= 10:
+                    print(f"  GPU {i}: {p[0]}")
+                    print(f"    Driver:       {p[9]}")
+                    print(f"    VRAM:         {p[2]} / {p[1]} MiB  (free: {p[3]} MiB)")
+                    print(f"    GPU Util:     {p[4]}%")
+                    print(f"    Mem Util:     {p[5]}%")
+                    print(f"    Temperature:  {p[6]} C")
+                    print(f"    Power:        {p[7]} / {p[8]} W")
+    except Exception as e:
+        print(f"  [GPU] error: {e}")
+    try:
+        with open("/proc/cpuinfo") as _f:
+            _ci = _f.read()
+        _cores = _ci.count("processor\t:")
+        _mn = ""
+        for _ln in _ci.split("\n"):
+            if _ln.startswith("model name"):
+                _mn = _ln.split(":", 1)[1].strip()
+                break
+        print(f"  CPU: {_mn}  ({_cores} cores)")
+    except:
+        pass
+    try:
+        with open("/proc/meminfo") as _f:
+            _mi = {}
+            for _ln in _f:
+                if ":" in _ln:
+                    _k, _v = _ln.split(":", 1)
+                    _mi[_k.strip()] = _v.strip()
+        _t = int(_mi.get("MemTotal", "0 kB").split()[0])
+        _a = int(_mi.get("MemAvailable", "0 kB").split()[0])
+        _u = _t - _a
+        print(f"  Memory: {_u / 1048576:.1f} / {_t / 1048576:.1f} GB  ({_u * 100 // _t}% used)")
+    except:
+        pass
+    try:
+        _st = _os.statvfs("/")
+        _td = _st.f_blocks * _st.f_frsize
+        _fd = _st.f_bavail * _st.f_frsize
+        _ud = _td - _fd
+        print(f"  Disk:   {_ud / (1024**3):.1f} / {_td / (1024**3):.1f} GB  (free: {_fd / (1024**3):.1f} GB)")
+    except:
+        pass
+    print("=" * 65)
+    print()
+
+def _monitor_metrics(interval=30):
+    import subprocess as _sp, time as _time, threading as _th
+    def _loop():
+        while True:
+            _time.sleep(interval)
+            try:
+                r = _sp.run(["nvidia-smi",
+                    "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw",
+                    "--format=csv,noheader,nounits"], capture_output=True, text=True, timeout=10)
+                if r.returncode == 0:
+                    for line in r.stdout.strip().split("\n"):
+                        p = [x.strip() for x in line.split(",")]
+                        if len(p) >= 5:
+                            print(f"[METRICS] GPU {p[0]}% | VRAM {p[1]}/{p[2]} MiB | {p[3]}C | {p[4]}W", flush=True)
+            except:
+                pass
+            try:
+                with open("/proc/loadavg") as _f:
+                    _la = _f.read().split()[:3]
+                print(f"[METRICS] CPU load {_la[0]} {_la[1]} {_la[2]}", flush=True)
+            except:
+                pass
+    _th.Thread(target=_loop, daemon=True).start()
+'''

--- a/m_gpux/commands/hub.py
+++ b/m_gpux/commands/hub.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tomlkit
 from typing import Optional
+from m_gpux.commands._metrics_snippet import FUNCTIONS as _METRICS_FUNCTIONS
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
@@ -78,12 +79,19 @@ def _activate_profile(profile_name: str):
         console.print(f"[bold red]Failed to activate profile '{profile_name}': {result.stderr.strip()}[/bold red]")
 
 AVAILABLE_GPUS = {
-    "1": ("T4", "Light inference/exploration"),
-    "2": ("L4", "Balance of cost/performance (24GB)"),
-    "3": ("A10G", "Good alternative for training/inference (24GB)"),
-    "4": ("A100", "High performance (40GB)"),
-    "5": ("A100-80GB", "Extreme performance (80GB)"),
-    "6": ("H100", "Top tier hopper architecture (80GB)"),
+    "1":  ("T4",            "Light inference/exploration (16GB)"),
+    "2":  ("L4",            "Balance of cost/performance (24GB)"),
+    "3":  ("A10G",          "Good alternative for training/inference (24GB)"),
+    "4":  ("L40S",          "Ada Lovelace, great for inference (48GB)"),
+    "5":  ("A100",          "High performance (40GB, default SXM)"),
+    "6":  ("A100-40GB",     "Ampere 40GB variant"),
+    "7":  ("A100-80GB",     "Extreme performance (80GB)"),
+    "8":  ("RTX-PRO-6000",   "RTX PRO 6000 — pro workstation GPU (48GB)"),
+    "9":  ("H100",          "Hopper architecture (80GB)"),
+    "10": ("H100!",         "H100 priority/reserved — guaranteed availability"),
+    "11": ("H200",          "Next-gen Hopper with HBM3e (141GB)"),
+    "12": ("B200",          "Blackwell architecture — latest gen"),
+    "13": ("B200+",         "B200 priority/reserved — guaranteed availability"),
 }
 
 JUPYTER_SCRIPT = """
@@ -91,11 +99,15 @@ import modal
 import subprocess
 import time
 
+# __METRICS__
+
 app = modal.App("m-gpux-jupyter")
 image = modal.Image.debian_slim().pip_install("jupyterlab")
 
 @app.function(image=image, gpu="{gpu_type}", timeout=86400)
 def run_jupyter():
+    _print_metrics()
+    _monitor_metrics()
     jupyter_port = 8888
     with modal.forward(jupyter_port) as tunnel:
         print(f"\\n=======================================================")
@@ -126,6 +138,8 @@ import modal
 import subprocess
 import sys
 
+# __METRICS__
+
 app = modal.App("m-gpux-runner")
 
 image = modal.Image.debian_slim(){pip_section}.add_local_dir(
@@ -134,6 +148,7 @@ image = modal.Image.debian_slim(){pip_section}.add_local_dir(
 
 @app.function(image=image, gpu="{gpu_type}", timeout=86400)
 def run_script():
+    _print_metrics()
     print("[EXECUTING] {script_name} on {gpu_type}...")
     stdin_input = {stdin_input}
     subprocess.run(
@@ -150,6 +165,8 @@ import subprocess
 import time
 import os
 
+# __METRICS__
+
 app = modal.App("m-gpux-interactive")
 image = modal.Image.debian_slim().apt_install("bash", "curl", "tmux").run_commands(
     "curl -sLo /usr/local/bin/ttyd https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64",
@@ -160,6 +177,8 @@ image = modal.Image.debian_slim().apt_install("bash", "curl", "tmux").run_comman
 
 @app.function(image=image, gpu="{gpu_type}", timeout=86400)
 def run_interactive():
+    _print_metrics()
+    _monitor_metrics()
     port = 8888
     # Start a tmux session so work survives browser disconnects
     subprocess.run(["tmux", "new-session", "-d", "-s", "main", "-c", "/workspace"])
@@ -185,6 +204,8 @@ def run_interactive():
 VLLM_SCRIPT = """
 import modal
 import subprocess
+
+# __METRICS__
 
 app = modal.App("m-gpux-vllm")
 
@@ -215,6 +236,8 @@ MINUTES = 60
 @modal.concurrent(max_inputs=50)
 @modal.web_server(port=8000, startup_timeout=10 * MINUTES)
 def serve():
+    _print_metrics()
+    _monitor_metrics()
     cmd = [
         "vllm", "serve", MODEL_NAME,
         "--served-model-name", MODEL_NAME, "llm",
@@ -232,6 +255,8 @@ import modal
 import subprocess
 import time
 
+# __METRICS__
+
 app = modal.App("m-gpux-shell")
 image = modal.Image.debian_slim().apt_install("bash", "curl").run_commands(
     "curl -sLo /usr/local/bin/ttyd https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64",
@@ -240,6 +265,8 @@ image = modal.Image.debian_slim().apt_install("bash", "curl").run_commands(
 
 @app.function(image=image, gpu="{gpu_type}", timeout=86400)
 def run_shell():
+    _print_metrics()
+    _monitor_metrics()
     port = 8888
     with modal.forward(port) as tunnel:
         print(f"\\n=======================================================")
@@ -251,6 +278,7 @@ def run_shell():
 
 
 def execute_modal_temp_script(content: str, description: str, detach: bool = False):
+    content = content.replace("# __METRICS__", _METRICS_FUNCTIONS)
     runner_file = "modal_runner.py"
     
     with open(runner_file, "w", encoding="utf-8") as f:
@@ -522,6 +550,7 @@ def hub_main():
         )
         
         if deploy_mode == "deploy":
+            script = script.replace("# __METRICS__", _METRICS_FUNCTIONS)
             runner_file = "modal_runner.py"
             with open(runner_file, "w", encoding="utf-8") as f:
                 f.write(script)

--- a/m_gpux/commands/load.py
+++ b/m_gpux/commands/load.py
@@ -1,0 +1,268 @@
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.live import Live
+from rich.layout import Layout
+from rich.text import Text
+import subprocess
+import json
+import time
+import os
+import tomlkit
+from typing import Optional
+
+app = typer.Typer(no_args_is_help=True)
+console = Console()
+
+MODAL_CONFIG_PATH = os.path.expanduser("~/.modal.toml")
+
+LOAD_SCRIPT = '''
+import modal
+import subprocess
+import json
+import time
+import sys
+
+app = modal.App("m-gpux-load-monitor")
+image = modal.Image.debian_slim().pip_install("gputil", "psutil")
+
+@app.function(image=image, gpu="{gpu_type}", timeout=120)
+def collect_metrics():
+    import GPUtil
+    import psutil
+    import platform
+
+    metrics = {{}}
+
+    # --- GPU metrics ---
+    gpus = GPUtil.getGPUs()
+    gpu_list = []
+    for g in gpus:
+        gpu_list.append({{
+            "id": g.id,
+            "name": g.name,
+            "driver": g.driver,
+            "memory_total_mb": round(g.memoryTotal, 1),
+            "memory_used_mb": round(g.memoryUsed, 1),
+            "memory_free_mb": round(g.memoryFree, 1),
+            "memory_util_pct": round(g.memoryUtil * 100, 1),
+            "gpu_util_pct": round(g.load * 100, 1),
+            "temperature_c": g.temperature,
+        }})
+    metrics["gpus"] = gpu_list
+
+    # --- CPU metrics ---
+    metrics["cpu"] = {{
+        "physical_cores": psutil.cpu_count(logical=False),
+        "logical_cores": psutil.cpu_count(logical=True),
+        "utilization_pct": psutil.cpu_percent(interval=1),
+        "freq_mhz": round(psutil.cpu_freq().current, 1) if psutil.cpu_freq() else None,
+        "processor": platform.processor() or platform.machine(),
+    }}
+
+    # --- Memory metrics ---
+    mem = psutil.virtual_memory()
+    metrics["memory"] = {{
+        "total_gb": round(mem.total / (1024**3), 2),
+        "used_gb": round(mem.used / (1024**3), 2),
+        "available_gb": round(mem.available / (1024**3), 2),
+        "utilization_pct": mem.percent,
+    }}
+
+    # --- Disk metrics ---
+    disk = psutil.disk_usage("/")
+    metrics["disk"] = {{
+        "total_gb": round(disk.total / (1024**3), 2),
+        "used_gb": round(disk.used / (1024**3), 2),
+        "free_gb": round(disk.free / (1024**3), 2),
+        "utilization_pct": disk.percent,
+    }}
+
+    # --- System info ---
+    metrics["system"] = {{
+        "platform": platform.system(),
+        "platform_release": platform.release(),
+        "architecture": platform.machine(),
+        "python_version": platform.python_version(),
+    }}
+
+    # --- Uptime / timing ---
+    boot = psutil.boot_time()
+    metrics["uptime_seconds"] = round(time.time() - boot, 1)
+
+    print("__METRICS_JSON_START__")
+    print(json.dumps(metrics))
+    print("__METRICS_JSON_END__")
+'''
+
+
+def _load_profiles():
+    if not os.path.exists(MODAL_CONFIG_PATH):
+        return []
+    with open(MODAL_CONFIG_PATH, "r", encoding="utf-8") as f:
+        doc = tomlkit.load(f)
+    profiles = []
+    for name in doc:
+        is_active = doc[name].get("active", False)
+        profiles.append((name, is_active))
+    return profiles
+
+
+def _get_active_profile() -> Optional[str]:
+    profiles = _load_profiles()
+    for name, is_active in profiles:
+        if is_active:
+            return name
+    if profiles:
+        return profiles[0][0]
+    return None
+
+
+def _bar(pct: float, width: int = 20) -> str:
+    filled = int(pct / 100 * width)
+    empty = width - filled
+    if pct >= 90:
+        color = "red"
+    elif pct >= 60:
+        color = "yellow"
+    else:
+        color = "green"
+    return f"[{color}]{'█' * filled}{'░' * empty}[/{color}] {pct:.1f}%"
+
+
+def _render_metrics(metrics: dict, gpu_type: str, elapsed: float) -> Panel:
+    """Build a rich Panel with all metrics."""
+    from rich.columns import Columns
+
+    tables = []
+
+    # --- GPU Table ---
+    for g in metrics.get("gpus", []):
+        gt = Table(title=f"GPU {g['id']}: {g['name']}", border_style="cyan", expand=True)
+        gt.add_column("Metric", style="bold white", ratio=1)
+        gt.add_column("Value", ratio=2)
+        gt.add_row("Driver", str(g["driver"]))
+        gt.add_row("VRAM Total", f"{g['memory_total_mb']:.0f} MB")
+        gt.add_row("VRAM Used", f"{g['memory_used_mb']:.0f} MB")
+        gt.add_row("VRAM Free", f"{g['memory_free_mb']:.0f} MB")
+        gt.add_row("VRAM Util", _bar(g["memory_util_pct"]))
+        gt.add_row("GPU Util", _bar(g["gpu_util_pct"]))
+        gt.add_row("Temperature", f"{g['temperature_c']}°C" if g["temperature_c"] else "N/A")
+        tables.append(gt)
+
+    # --- CPU Table ---
+    cpu = metrics.get("cpu", {})
+    ct = Table(title="CPU", border_style="green", expand=True)
+    ct.add_column("Metric", style="bold white", ratio=1)
+    ct.add_column("Value", ratio=2)
+    ct.add_row("Processor", str(cpu.get("processor", "N/A")))
+    ct.add_row("Physical Cores", str(cpu.get("physical_cores", "N/A")))
+    ct.add_row("Logical Cores", str(cpu.get("logical_cores", "N/A")))
+    ct.add_row("Frequency", f"{cpu['freq_mhz']} MHz" if cpu.get("freq_mhz") else "N/A")
+    ct.add_row("Utilization", _bar(cpu.get("utilization_pct", 0)))
+    tables.append(ct)
+
+    # --- Memory Table ---
+    mem = metrics.get("memory", {})
+    mt = Table(title="System Memory", border_style="magenta", expand=True)
+    mt.add_column("Metric", style="bold white", ratio=1)
+    mt.add_column("Value", ratio=2)
+    mt.add_row("Total", f"{mem.get('total_gb', 0):.2f} GB")
+    mt.add_row("Used", f"{mem.get('used_gb', 0):.2f} GB")
+    mt.add_row("Available", f"{mem.get('available_gb', 0):.2f} GB")
+    mt.add_row("Utilization", _bar(mem.get("utilization_pct", 0)))
+    tables.append(mt)
+
+    # --- Disk Table ---
+    disk = metrics.get("disk", {})
+    dt = Table(title="Disk", border_style="yellow", expand=True)
+    dt.add_column("Metric", style="bold white", ratio=1)
+    dt.add_column("Value", ratio=2)
+    dt.add_row("Total", f"{disk.get('total_gb', 0):.2f} GB")
+    dt.add_row("Used", f"{disk.get('used_gb', 0):.2f} GB")
+    dt.add_row("Free", f"{disk.get('free_gb', 0):.2f} GB")
+    dt.add_row("Utilization", _bar(disk.get("utilization_pct", 0)))
+    tables.append(dt)
+
+    # --- System / Timing ---
+    sys_info = metrics.get("system", {})
+    uptime = metrics.get("uptime_seconds", 0)
+    st = Table(title="System & Timing", border_style="bright_blue", expand=True)
+    st.add_column("Metric", style="bold white", ratio=1)
+    st.add_column("Value", ratio=2)
+    st.add_row("Platform", f"{sys_info.get('platform', '')} {sys_info.get('platform_release', '')}")
+    st.add_row("Architecture", str(sys_info.get("architecture", "N/A")))
+    st.add_row("Python", str(sys_info.get("python_version", "N/A")))
+    st.add_row("Container Uptime", f"{uptime:.0f}s ({uptime/60:.1f} min)")
+    st.add_row("Probe Round-trip", f"{elapsed:.1f}s")
+    tables.append(st)
+
+    from rich.columns import Columns
+    grid = Columns(tables, equal=True, expand=True)
+    return Panel(grid, title=f"[bold cyan]m-gpux load — {gpu_type}[/bold cyan]", border_style="bright_cyan", expand=True)
+
+
+# Import the hub GPU list so we stay in sync
+from m_gpux.commands.hub import AVAILABLE_GPUS
+
+
+@app.command("probe")
+def load_probe(
+    gpu: str = typer.Option(None, "--gpu", "-g", help="GPU type to probe (e.g. T4, A100, H100). If omitted, shows picker."),
+):
+    """
+    Spin up a short-lived Modal container and report GPU, CPU, memory, disk,
+    and timing metrics back to the terminal.
+    """
+    if gpu is None:
+        console.print("\n[bold cyan]Select GPU to probe:[/bold cyan]")
+        for k, (name, desc) in AVAILABLE_GPUS.items():
+            console.print(f"  [bold yellow]{k:>2}[/bold yellow]: {name:<14} — {desc}")
+        from rich.prompt import Prompt
+        gpu_choice = Prompt.ask("Select GPU", choices=list(AVAILABLE_GPUS.keys()), default="1")
+        gpu = AVAILABLE_GPUS[gpu_choice][0]
+
+    console.print(f"\n[cyan]Probing [bold]{gpu}[/bold] — spinning up container...[/cyan]")
+
+    script_content = LOAD_SCRIPT.replace("{gpu_type}", gpu)
+    runner_file = "_m_gpux_load_probe.py"
+
+    with open(runner_file, "w", encoding="utf-8") as f:
+        f.write(script_content)
+
+    t0 = time.time()
+    try:
+        result = subprocess.run(
+            ["modal", "run", runner_file],
+            capture_output=True, text=True, timeout=300,
+        )
+        elapsed = time.time() - t0
+
+        output = result.stdout + result.stderr
+
+        if "__METRICS_JSON_START__" in output:
+            json_str = output.split("__METRICS_JSON_START__")[1].split("__METRICS_JSON_END__")[0].strip()
+            metrics = json.loads(json_str)
+            panel = _render_metrics(metrics, gpu, elapsed)
+            console.print()
+            console.print(panel)
+        else:
+            console.print(f"[bold red]Could not parse metrics from container output.[/bold red]")
+            if output.strip():
+                console.print(Panel(output.strip(), title="Raw Output", border_style="red"))
+
+        if result.returncode != 0 and "__METRICS_JSON_START__" not in output:
+            console.print(f"[bold red]modal run exited with code {result.returncode}[/bold red]")
+
+    except subprocess.TimeoutExpired:
+        console.print("[bold red]Probe timed out after 300s.[/bold red]")
+    except FileNotFoundError:
+        console.print("[bold red]'modal' CLI not found. Make sure Modal is installed.[/bold red]")
+    except Exception as e:
+        console.print(f"[bold red]Error: {e}[/bold red]")
+    finally:
+        try:
+            os.remove(runner_file)
+        except OSError:
+            pass

--- a/m_gpux/main.py
+++ b/m_gpux/main.py
@@ -7,6 +7,7 @@ from m_gpux import __version__
 from m_gpux.commands import account
 from m_gpux.commands import billing
 from m_gpux.commands import hub
+from m_gpux.commands import load
 
 app = typer.Typer(
     name="m-gpux", 
@@ -21,6 +22,7 @@ console = Console()
 app.add_typer(account.app, name="account", help="Configure identities and add multiple Modal profiles.", rich_help_panel="Identity & Finance")
 app.add_typer(billing.app, name="billing", help="Track infrastructure costs across workspaces.", rich_help_panel="Identity & Finance")
 app.command(name="hub", help="Launch interactive UI to provision Python scripts, Terminals, or Jupyter on GPUs.", rich_help_panel="Compute Engine")(hub.hub_main)
+app.add_typer(load.app, name="load", help="Probe a GPU container and display live hardware metrics.", rich_help_panel="Compute Engine")
 
 HERO_LOGO = """
 [bold cyan] ███╗   ███╗      ██████╗ ██████╗ ██╗   ██╗██╗  ██╗[/bold cyan]
@@ -37,6 +39,7 @@ def render_welcome() -> None:
     quick_actions = Table.grid(padding=(0, 2))
     quick_actions.add_row("[bold yellow]m-gpux account add[/bold yellow]", "Configure your Modal token profile")
     quick_actions.add_row("[bold yellow]m-gpux hub[/bold yellow]", "Launch Jupyter, script runner, or web shell")
+    quick_actions.add_row("[bold yellow]m-gpux load probe[/bold yellow]", "Probe a GPU and display hardware metrics")
     quick_actions.add_row("[bold yellow]m-gpux billing usage --all[/bold yellow]", "See total spend across configured accounts")
 
     console.print(Panel.fit(HERO_LOGO.strip(), border_style="bright_cyan", title="M-GPUX", subtitle=f"v{__version__}"))

--- a/openclaw-skill/m-gpux/SKILL.md
+++ b/openclaw-skill/m-gpux/SKILL.md
@@ -27,11 +27,21 @@ m-gpux account switch <profile-name>
 ```bash
 # Launch interactive GPU provisioning wizard
 # Step 0: Select workspace (0=AUTO smart pick)
-# Step 1: Choose GPU (T4/L4/A10G/A100/A100-80GB/H100)
+# Step 1: Choose GPU (T4/L4/A10G/L40S/A100/A100-40GB/A100-80GB/RTX6000-Ada/H100/H100!/H200/B200/B200+)
 # Step 2: Choose app (Jupyter / Python Script / Bash Shell)
 # Step 3: Environment setup (requirements.txt auto-detect)
 # Step 4: File upload config (exclude patterns like .venv, __pycache__)
 m-gpux hub
+```
+
+### Load (GPU Metrics Probe)
+```bash
+# Probe a GPU and display full hardware metrics (GPU, CPU, RAM, Disk, Timing)
+m-gpux load probe
+
+# Probe a specific GPU type directly
+m-gpux load probe --gpu H100
+m-gpux load probe -g B200
 ```
 
 ### Billing
@@ -56,15 +66,23 @@ When the user asks to run something on a GPU, use these strategies:
    - T4: ~$0.59/hr (cheapest, good for light inference)
    - L4: ~$0.80/hr
    - A10G: ~$1.10/hr
+   - L40S: ~$1.40/hr
    - A100 40GB: ~$3.10/hr
    - A100 80GB: ~$4.06/hr
-   - H100: ~$4.89/hr (most expensive)
+   - RTX PRO 6000: ~$1.52/hr
+   - H100: ~$4.89/hr
+   - H100!: ~$4.89/hr (reserved, guaranteed availability)
+   - H200: ~$6.35/hr
+   - B200: ~$7.41/hr
+   - B200+: ~$7.41/hr (reserved, guaranteed availability)
 
 When recommending GPUs, consider the task:
 - **Light inference / testing**: T4 or L4
-- **Training small models / fine-tuning**: A10G or A100
-- **Large model inference (7B+ params)**: A100-80GB or H100
-- **Training large models**: H100 or A100-80GB
+- **Training small models / fine-tuning**: A10G, L40S, or A100
+- **Large model inference (7B+ params)**: A100-80GB, H100, or H200
+- **Training large models**: H100, H200, B200
+- **Cutting-edge / maximum throughput**: B200 or B200+
+- **Pro workstation workloads**: RTX PRO 6000
 
 ## Example Workflows
 
@@ -75,6 +93,9 @@ When recommending GPUs, consider the task:
 
 ### User: "How much credit do I have left?"
 Run: `m-gpux account list` and summarize the table.
+
+### User: "Check what hardware specs an H100 has"
+Run: `m-gpux load probe --gpu H100` — this spins up a short-lived container and reports GPU VRAM, CPU cores, RAM, disk, driver version, temperature, and round-trip time.
 
 ### User: "Launch a Jupyter notebook with an A100"
 Guide: `m-gpux hub` → auto account → A100 → Jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m-gpux"
-version = "1.0.3"
+version = "1.0.4"
 description = "Professional CLI toolkit for Modal GPU workflows, account management, and billing visibility"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
…ommand

- Expand AVAILABLE_GPUS: T4, L4, A10G, L40S, A100, A100-40GB, A100-80GB, RTX-PRO-6000, H100, H100!, H200, B200, B200+
- Inject hardware metrics into all container scripts (GPU/CPU/RAM/Disk/Power/Temp)
- Add periodic metrics monitor (every 30s) for long-running containers
- New 'm-gpux load probe' command to probe GPU hardware specs
- Update SKILL.md with full GPU list and pricing