### PR TITLE
Release/v1.0.8

### DIFF
--- a/_regen.py
+++ b/_regen.py
@@ -1,0 +1,29 @@
+"""Regenerate modal_runner.py for deployment."""
+from m_gpux.commands.serve import SERVE_TEMPLATE, _get_active_keys
+from m_gpux.commands._metrics_snippet import FUNCTIONS
+
+model = "Qwen/Qwen3.5-35B-A3B"
+gpu = "A100-80GB"
+keys = _get_active_keys()
+api_key = keys[0] if keys else "sk-mgpux-test"
+
+env_dict = '{"HF_HUB_ENABLE_HF_TRANSFER": "1"}'
+volumes_dict = '{\n        "/root/.cache/huggingface": hf_cache,\n        "/root/.cache/vllm": vllm_cache,\n    }'
+
+script = (SERVE_TEMPLATE
+    .replace("{model_name}", model)
+    .replace("{gpu_type}", gpu)
+    .replace("{api_key}", api_key)
+    .replace("{max_model_len}", "4096")
+    .replace("{keep_warm}", "1")
+    .replace("ENV_DICT_PLACEHOLDER", env_dict)
+    .replace("VOLUMES_PLACEHOLDER", volumes_dict)
+    .replace("# __METRICS__", FUNCTIONS))
+
+with open("modal_runner.py", "w", encoding="utf-8") as f:
+    f.write(script)
+
+for i, line in enumerate(script.split("\n")):
+    if "Popen" in line or "API_KEY" in line or "port 800" in line:
+        print(f"  L{i}: {line.strip()}")
+print("Generated OK")

--- a/_test_auth.py
+++ b/_test_auth.py
@@ -1,0 +1,48 @@
+"""Test auth proxy on deployed endpoint."""
+import urllib.request
+import urllib.error
+import json
+
+BASE = "https://puxpuxx--m-gpux-llm-api-serve.modal.run"
+GOOD_KEY = "sk-mgpux-8b37a191eb046c68b9805c1d381a61a2b33a7464c6c0bbe6"
+
+# Test 1: /health (no auth)
+print("=== Test 1: /health (no auth) ===")
+try:
+    r = urllib.request.urlopen(f"{BASE}/health", timeout=600)
+    print(f"  Status: {r.status}")
+    print(f"  Body: {json.loads(r.read())}")
+except Exception as e:
+    print(f"  Error: {e}")
+
+# Test 2: /v1/models WITHOUT key (should be 401)
+print("\n=== Test 2: /v1/models without key ===")
+try:
+    r = urllib.request.urlopen(f"{BASE}/v1/models", timeout=30)
+    print(f"  Status: {r.status} (FAIL - should be 401)")
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code} (expected 401)")
+
+# Test 3: /v1/models WITH correct key
+print("\n=== Test 3: /v1/models with valid key ===")
+req = urllib.request.Request(f"{BASE}/v1/models")
+req.add_header("Authorization", f"Bearer {GOOD_KEY}")
+try:
+    r = urllib.request.urlopen(req, timeout=60)
+    data = json.loads(r.read())
+    models = [m["id"] for m in data.get("data", [])]
+    print(f"  Status: {r.status}")
+    print(f"  Models: {models}")
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code}")
+    print(f"  Body: {e.read().decode()}")
+
+# Test 4: /v1/models WITH wrong key (should be 403)
+print("\n=== Test 4: /v1/models with wrong key ===")
+req = urllib.request.Request(f"{BASE}/v1/models")
+req.add_header("Authorization", "Bearer sk-mgpux-wrongkey123")
+try:
+    r = urllib.request.urlopen(req, timeout=30)
+    print(f"  Status: {r.status} (FAIL - should be 403)")
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code} (expected 403)")

--- a/_test_full.py
+++ b/_test_full.py
@@ -1,0 +1,167 @@
+"""Full end-to-end test: auth + inference (non-stream + stream)."""
+import urllib.request
+import urllib.error
+import json
+import time
+
+BASE = "https://puxpuxx--m-gpux-llm-api-serve.modal.run"
+KEY = "sk-mgpux-8b37a191eb046c68b9805c1d381a61a2b33a7464c6c0bbe6"
+MODEL = "Qwen/Qwen3.5-35B-A3B"
+
+passed = 0
+failed = 0
+
+def ok(name, cond):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  [PASS] {name}")
+    else:
+        failed += 1
+        print(f"  [FAIL] {name}")
+
+# ── Wait for vLLM ──
+print("=== Waiting for vLLM to be ready... ===")
+start = time.time()
+while True:
+    try:
+        r = urllib.request.urlopen(f"{BASE}/health", timeout=600)
+        data = json.loads(r.read())
+        elapsed = time.time() - start
+        if data.get("vllm_ready"):
+            print(f"  vLLM ready! ({elapsed:.1f}s)")
+            break
+        ready = data.get("vllm_ready")
+        print(f"  [{elapsed:.0f}s] vllm_ready={ready}")
+        time.sleep(10)
+    except Exception as e:
+        elapsed = time.time() - start
+        print(f"  [{elapsed:.0f}s] Error: {e}")
+        time.sleep(10)
+
+# ── Test 1: /health ──
+print("\n=== Test 1: /health (no auth) ===")
+r = urllib.request.urlopen(f"{BASE}/health", timeout=30)
+data = json.loads(r.read())
+print(f"  Status: {r.status}")
+print(f"  Body: {data}")
+ok("status=200", r.status == 200)
+ok("vllm_ready=True", data.get("vllm_ready") is True)
+
+# ── Test 2: /v1/models no key => 401 ──
+print("\n=== Test 2: /v1/models WITHOUT key => 401 ===")
+try:
+    urllib.request.urlopen(f"{BASE}/v1/models", timeout=30)
+    ok("401", False)
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code}")
+    ok("401", e.code == 401)
+
+# ── Test 3: /v1/models wrong key => 403 ──
+print("\n=== Test 3: /v1/models WITH wrong key => 403 ===")
+req = urllib.request.Request(f"{BASE}/v1/models")
+req.add_header("Authorization", "Bearer sk-wrong-key")
+try:
+    urllib.request.urlopen(req, timeout=30)
+    ok("403", False)
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code}")
+    ok("403", e.code == 403)
+
+# ── Test 4: /v1/models valid key => 200 ──
+print("\n=== Test 4: /v1/models WITH valid key => 200 ===")
+req = urllib.request.Request(f"{BASE}/v1/models")
+req.add_header("Authorization", f"Bearer {KEY}")
+r = urllib.request.urlopen(req, timeout=30)
+data = json.loads(r.read())
+models = [m["id"] for m in data.get("data", [])]
+print(f"  Status: {r.status}")
+print(f"  Models: {models}")
+ok("status=200", r.status == 200)
+ok("model in list", MODEL in models)
+
+# ── Test 5: Chat completion (non-streaming) ──
+print("\n=== Test 5: Chat completion (non-streaming) ===")
+payload = json.dumps({
+    "model": MODEL,
+    "messages": [{"role": "user", "content": "Say hello in 5 words."}],
+    "max_tokens": 50,
+    "temperature": 0.7,
+    "stream": False,
+}).encode()
+req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=payload, method="POST")
+req.add_header("Authorization", f"Bearer {KEY}")
+req.add_header("Content-Type", "application/json")
+t0 = time.time()
+r = urllib.request.urlopen(req, timeout=120)
+latency = time.time() - t0
+data = json.loads(r.read())
+msg = data["choices"][0]["message"]["content"]
+usage = data.get("usage", {})
+print(f"  Status: {r.status}")
+print(f"  Latency: {latency:.2f}s")
+print(f"  Response: {msg}")
+print(f"  Usage: {usage}")
+ok("status=200", r.status == 200)
+ok("has content", len(msg) > 0)
+
+# ── Test 6: Chat completion (streaming) ──
+print("\n=== Test 6: Chat completion (streaming) ===")
+payload = json.dumps({
+    "model": MODEL,
+    "messages": [{"role": "user", "content": "Count from 1 to 5."}],
+    "max_tokens": 100,
+    "temperature": 0.7,
+    "stream": True,
+}).encode()
+req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=payload, method="POST")
+req.add_header("Authorization", f"Bearer {KEY}")
+req.add_header("Content-Type", "application/json")
+t0 = time.time()
+r = urllib.request.urlopen(req, timeout=120)
+ttft = None
+chunks = 0
+full_text = ""
+for line in r:
+    line = line.decode().strip()
+    if line.startswith("data: ") and line != "data: [DONE]":
+        if ttft is None:
+            ttft = time.time() - t0
+        chunks += 1
+        try:
+            d = json.loads(line[6:])
+            delta = d["choices"][0]["delta"].get("content", "")
+            full_text += delta
+        except Exception:
+            pass
+total = time.time() - t0
+print(f"  Status: {r.status}")
+print(f"  TTFT: {ttft:.2f}s" if ttft else "  TTFT: N/A")
+print(f"  Total: {total:.2f}s")
+print(f"  Chunks: {chunks}")
+print(f"  Response: {full_text}")
+ok("status=200", r.status == 200)
+ok("has chunks", chunks > 0)
+ok("has content", len(full_text) > 0)
+
+# ── Test 7: Chat completion no key => 401 ──
+print("\n=== Test 7: Chat /v1/chat/completions WITHOUT key => 401 ===")
+payload = json.dumps({
+    "model": MODEL,
+    "messages": [{"role": "user", "content": "Hi"}],
+    "stream": False,
+}).encode()
+req = urllib.request.Request(f"{BASE}/v1/chat/completions", data=payload, method="POST")
+req.add_header("Content-Type", "application/json")
+try:
+    urllib.request.urlopen(req, timeout=30)
+    ok("401", False)
+except urllib.error.HTTPError as e:
+    print(f"  Status: {e.code}")
+    ok("401", e.code == 401)
+
+# ── Summary ──
+print(f"\n{'='*40}")
+print(f"  PASSED: {passed}/{passed+failed}")
+print(f"  FAILED: {failed}/{passed+failed}")
+print(f"{'='*40}")

--- a/m_gpux/__init__.py
+++ b/m_gpux/__init__.py
@@ -1,3 +1,3 @@
 """m_gpux package."""
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/m_gpux/__init__.py
+++ b/m_gpux/__init__.py
@@ -1,3 +1,3 @@
 """m_gpux package."""
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -256,7 +256,6 @@ def serve():
         "--served-model-name", MODEL_NAME,
         "--host", "0.0.0.0",
         "--port", "8001",
-        "--enforce-eager",
         "--tensor-parallel-size", "1",
         "--max-model-len", "{max_model_len}",
     ]

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -220,9 +220,14 @@ async def proxy(request: Request, path: str):
                     yield f"data: {err}{nl}{nl}data: [DONE]{nl}{nl}".encode()
             return StreamingResponse(gen(), media_type="text/event-stream")
         r = await http_client.request(request.method, f"/v1/{path}", content=body, headers=headers)
-        return Response(content=r.content, status_code=r.status_code, media_type=r.headers.get("content-type","application/json"))
+        resp_body = r.content
+        return Response(content=resp_body, status_code=r.status_code,
+                        headers={"content-length": str(len(resp_body))},
+                        media_type=r.headers.get("content-type","application/json"))
     except (httpx.ConnectError, httpx.TimeoutException):
         return JSONResponse(status_code=503, content={"error":{"message":"Model is still loading. Try again in a minute.","type":"server_error"}})
+    except Exception as exc:
+        return JSONResponse(status_code=502, content={"error":{"message":f"Backend error: {exc}","type":"server_error"}})
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info",

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -148,7 +148,7 @@ API_KEY = "{api_key}"
 vllm_image = (
     modal.Image.from_registry("nvidia/cuda:12.8.1-devel-ubuntu22.04", add_python="3.12")
     .entrypoint([])
-    .pip_install("vllm", "transformers", "hf-transfer", "httpx", "fastapi", "uvicorn")
+    .pip_install("vllm", "transformers", "hf-transfer", "httpx", "fastapi", "uvicorn[standard]")
     .env(ENV_DICT_PLACEHOLDER)
 )
 
@@ -209,21 +209,18 @@ async def proxy(request: Request, path: str):
         try: is_stream = json.loads(body).get("stream", False)
         except: pass
     try:
+        async def stream_response():
+            async with http_client.stream(request.method, f"/v1/{path}", content=body, headers=headers) as r:
+                async for chunk in r.aiter_bytes():
+                    yield chunk
         if is_stream:
-            async def gen():
-                try:
-                    async with http_client.stream(request.method, f"/v1/{path}", content=body, headers=headers) as r:
-                        async for chunk in r.aiter_bytes(): yield chunk
-                except Exception as e:
-                    err = json.dumps({"error":{"message":str(e),"type":"server_error"}})
-                    nl = chr(10)
-                    yield f"data: {err}{nl}{nl}data: [DONE]{nl}{nl}".encode()
-            return StreamingResponse(gen(), media_type="text/event-stream")
+            return StreamingResponse(stream_response(), media_type="text/event-stream")
         r = await http_client.request(request.method, f"/v1/{path}", content=body, headers=headers)
-        resp_body = r.content
-        return Response(content=resp_body, status_code=r.status_code,
-                        headers={"content-length": str(len(resp_body))},
-                        media_type=r.headers.get("content-type","application/json"))
+        return StreamingResponse(
+            iter([r.content]),
+            status_code=r.status_code,
+            media_type=r.headers.get("content-type", "application/json"),
+        )
     except (httpx.ConnectError, httpx.TimeoutException):
         return JSONResponse(status_code=503, content={"error":{"message":"Model is still loading. Try again in a minute.","type":"server_error"}})
     except Exception as exc:
@@ -232,7 +229,7 @@ async def proxy(request: Request, path: str):
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info",
                 backlog=2048, limit_concurrency=200, limit_max_requests=None,
-                timeout_keep_alive=120, h11_max_incomplete_event_size=0)
+                timeout_keep_alive=120)
 """
 
 

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -258,6 +258,11 @@ def serve():
         "--port", "8001",
         "--tensor-parallel-size", "1",
         "--max-model-len", "{max_model_len}",
+        "--gpu-memory-utilization", "0.95",
+        "--enable-prefix-caching",
+        "--num-scheduler-steps", "10",
+        "--max-num-seqs", "128",
+        "--enable-chunked-prefill",
     ]
     print("[M-GPUX] Starting vLLM on :8001:", " ".join(vllm_cmd))
     subprocess.Popen(vllm_cmd)

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -260,7 +260,6 @@ def serve():
         "--max-model-len", "{max_model_len}",
         "--gpu-memory-utilization", "0.95",
         "--enable-prefix-caching",
-        "--num-scheduler-steps", "10",
         "--max-num-seqs", "128",
         "--enable-chunked-prefill",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m-gpux"
-version = "1.0.9"
+version = "1.0.10"
 description = "Professional CLI toolkit for Modal GPU workflows, account management, and billing visibility"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m-gpux"
-version = "1.0.10"
+version = "1.0.11"
 description = "Professional CLI toolkit for Modal GPU workflows, account management, and billing visibility"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request introduces several important updates aimed at improving deployment, authentication, and testing for the `m_gpux` package and its model-serving workflow. The changes include new end-to-end and authentication tests, enhancements to the model serving configuration, improved error handling in the API proxy, and a version bump to reflect these updates.

**Testing and Validation Improvements:**

* Added `_test_full.py` to provide a comprehensive end-to-end test covering health checks, authentication (valid/invalid/missing keys), and both streaming and non-streaming chat completions to ensure the deployed endpoint works as expected.
* Added `_test_auth.py` to specifically test the authentication proxy on the deployed endpoint, verifying correct handling of missing, valid, and invalid API keys.

**Deployment and Regeneration Enhancements:**

* Introduced `_regen.py` to automate the generation of `modal_runner.py` for deployment, dynamically filling in model, GPU, API key, environment, and metrics configuration.

**Model Serving and API Proxy Improvements:**

* Updated the vLLM container configuration in `serve.py` to use `uvicorn[standard]` for a more robust ASGI server, and added several vLLM launch flags for improved performance and reliability (e.g., `--gpu-memory-utilization`, `--enable-prefix-caching`). [[1]](diffhunk://#diff-b0f8a306dc4092e8cc03c7b5858e8ccf32bd3d2ba1aa8b3093a4007e2242f88cL151-R151) [[2]](diffhunk://#diff-b0f8a306dc4092e8cc03c7b5858e8ccf32bd3d2ba1aa8b3093a4007e2242f88cL254-R261)
* Refactored the proxy endpoint in `serve.py` to improve error handling and response streaming, including more robust backend error reporting and simplified streaming logic.

**Versioning:**

* Bumped the package version from `1.0.9` to `1.0.11` in both `m_gpux/__init__.py` and `pyproject.toml` to reflect these changes. [[1]](diffhunk://#diff-4cf103c1ca46958b984d722d2e4dd6751e9d27f6c4093067197e11c85cac4ad9L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)