### PR TITLE
v1.0.13: live dashboard, resilient proxy, vLLM hyperparameter tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Turn your HuggingFace models into live endpoints.
 
 ```bash
 m-gpux serve deploy             # Deploy a model (interactive wizard)
-m-gpux serve warmup             # Check warm status
+m-gpux serve dashboard          # Live metrics dashboard in terminal
+m-gpux serve logs               # Stream server logs
+m-gpux serve warmup             # Trigger cold start and warm up engine
 m-gpux serve stop               # Stop the server
 
 # Secure your endpoints
@@ -128,8 +130,10 @@ m-gpux serve keys revoke <name> # Revoke access
 
 **Key Features:**
 - Bearer token authentication (401/403).
-- Full Support for streaming & non-streaming chat completions.
-- Intuitively configurable GPU selection, context lengths, and keep-warm containers.
+- Full support for streaming & non-streaming chat completions.
+- **Live dashboard** — GPU/CPU/RAM metrics, latency percentiles, traffic, and token counts with progress bars.
+- **Resilient proxy** — automatic retry with backoff, backpressure (429), internal streaming to prevent timeouts on long inference.
+- Configurable vLLM hyperparameters (GPU memory utilization, tensor parallelism, max sequences).
 - 11 built-in popular model presets (Qwen, Llama, Gemma, Phi, etc.).
 
 ### 💸 Billing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,21 +92,37 @@ Modal's `@modal.web_server(port=8000)` requires a server to be listening on the 
 Client Request
     │
     ▼
-┌─ Auth Middleware ─────────────────────────────┐
-│  1. Is path /health, /, /docs, /openapi.json? │
-│     → YES: Pass through (no auth)             │
-│     → NO: Check Authorization header          │
-│                                               │
-│  2. No "Bearer" prefix?                       │
-│     → 401 {"error": "Missing API key..."}     │
-│                                               │
-│  3. Key doesn't match?                        │
-│     → 403 {"error": "Invalid API key"}        │
-│                                               │
-│  4. Valid key                                  │
-│     → Proxy to vLLM on localhost:8001         │
-└───────────────────────────────────────────────┘
+┌─ Auth Middleware ──────────────────────────────────┐
+│  1. Is path /health, /, /docs, /openapi.json,     │
+│     /stats?                                        │
+│     → YES: Pass through (no auth)                  │
+│     → NO: Check Authorization header               │
+│                                                    │
+│  2. No "Bearer" prefix?                            │
+│     → 401 {"error": "Missing API key..."}          │
+│                                                    │
+│  3. Key doesn't match?                             │
+│     → 403 {"error": "Invalid API key"}             │
+│                                                    │
+│  4. Too many concurrent requests (>150)?           │
+│     → 429 {"error": "Too many concurrent..."}      │
+│                                                    │
+│  5. Valid key + capacity available                  │
+│     → Proxy to vLLM on localhost:8001 (with retry) │
+└────────────────────────────────────────────────────┘
 ```
+
+### Proxy Resilience
+
+The auth proxy includes several features to prevent request loss under load:
+
+| Feature | Details |
+|---|---|
+| **Retry with backoff** | 3 attempts with 1s→2s→4s delays on `ConnectError`, `TimeoutException`, `RemoteProtocolError`, `ReadError` |
+| **Backpressure (429)** | Tracks in-flight requests; rejects with 429 when >150 concurrent |
+| **Internal streaming** | Non-stream requests use `httpx.stream()` internally to collect chunks — keeps connection alive during long inference (prevents timeout on 5+ min completions) |
+| **Stream error recovery** | Streaming responses catch mid-stream errors and yield a proper SSE error event instead of leaving truncated responses (prevents `TransferEncodingError`) |
+| **Metrics tracking** | Every request's latency, status, token usage tracked for `/stats` and `dashboard` |
 
 ### Streaming
 
@@ -136,7 +152,7 @@ Subsequent deploys: weights are already cached (cold start ~1-3 min).
 | `min_containers=1` | One container always running. Response time ~0.9s. Costs GPU time continuously. |
 | `scaledown_window=5min` | After last request, container stays warm for 5 minutes before scaling down. |
 | `timeout=24h` | Max container lifetime before forced restart. |
-| `max_inputs=50` | Up to 50 concurrent requests per container (via `@modal.concurrent`). |
+| `max_inputs=200` | Up to 200 concurrent requests per container (via `@modal.concurrent`). |
 
 ### API Key Storage
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -190,15 +190,17 @@ Interactive 5-step wizard to deploy a model:
 | 1 | Model (11 presets or custom HuggingFace ID) | `Qwen/Qwen2.5-7B-Instruct` |
 | 2 | GPU type | Recommended for selected model |
 | 3 | Max context length (tokens) | `4096` |
+| 3.5 | vLLM engine tuning (GPU mem utilization, max seqs, tensor parallel) | `0.92`, `128`, `1` |
 | 4 | Min containers / keep warm | `1` |
 | 5 | API key (select existing or auto-create) | First active key |
 
 **What gets deployed:**
 
 - A Modal app named `m-gpux-llm-api` with:
-    - **Auth proxy** (FastAPI + uvicorn on port 8000) — validates `Authorization: Bearer` headers
+    - **Auth proxy** (FastAPI + uvicorn on port 8000) — validates `Authorization: Bearer` headers, retry with backoff, backpressure (429 when overloaded), internal streaming for long inference
     - **vLLM backend** (on port 8001) — OpenAI-compatible `/v1/chat/completions`, `/v1/models`, etc.
     - **Shared Volumes** — `m-gpux-hf-cache` and `m-gpux-vllm-cache` persist model weights across deployments
+    - **Stats endpoint** (`/stats`) — real-time metrics: inflight requests, latency percentiles, token counts, GPU/CPU/RAM/disk usage
 
 **Endpoint URL format:**
 
@@ -214,15 +216,58 @@ https://<workspace>--m-gpux-llm-api-serve.modal.run
 | Invalid key | `403 Forbidden` |
 | Valid key | Request proxied to vLLM |
 | `/health` endpoint | Always `200 OK` (no auth required) |
+| `/stats` endpoint | Always `200 OK` (no auth required) |
+| Too many concurrent requests | `429 Too Many Requests` with `retry_after` |
 
 **Supported API routes:**
 
 | Route | Method | Description |
 |---|---|---|
-| `/health` | GET | Health check + vLLM readiness |
+| `/health` | GET | Health check + vLLM readiness + inflight count |
+| `/stats` | GET | Full metrics: latency, throughput, GPU/CPU/RAM, tokens |
 | `/v1/models` | GET | List loaded models |
 | `/v1/chat/completions` | POST | Chat completion (streaming & non-streaming) |
 | `/v1/completions` | POST | Text completion |
+
+**Proxy resilience features:**
+
+| Feature | Behavior |
+|---|---|
+| Retry with backoff | 3 attempts with 1s, 2s, 4s delays on connection errors |
+| Backpressure | Returns 429 when >150 concurrent requests in-flight |
+| Internal streaming | Non-stream requests use streaming internally to prevent timeout on long inference |
+| Error recovery | `RemoteProtocolError`, `ReadError` caught and retried; stream errors yield SSE error event |
+
+### dashboard
+
+```bash
+m-gpux serve dashboard
+m-gpux serve dashboard --url https://workspace--m-gpux-llm-api-serve.modal.run
+m-gpux serve dashboard --interval 5
+```
+
+| Option | Description | Default |
+|---|---|---|
+| `--url`, `-u` | Base URL of the deployed API | Auto-detected from profiles |
+| `--interval`, `-i` | Refresh interval in seconds | `3.0` |
+
+Live terminal dashboard with Rich, showing:
+
+- **GPU** — VRAM usage, compute utilization, memory bandwidth, temperature, power draw (progress bars)
+- **System** — CPU load, RAM usage, disk usage (progress bars)
+- **Traffic** — in-flight requests with capacity bar, success rate, error counts (4xx/5xx/429)
+- **Latency** — avg, P50, P95, P99, min, max with scaled bars
+- **Tokens** — prompt/completion counts with ratio bars
+
+Color coding: cyan (<40%) → green (<70%) → yellow (<90%) → red (≥90%).
+
+### logs
+
+```bash
+m-gpux serve logs
+```
+
+Streams live logs from the deployed `m-gpux-llm-api` app. Press Ctrl+C to stop.
 
 ### stop
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ The hub generates a `modal_runner.py` script, shows it for review, then executes
 
 ```bash
 m-gpux serve keys create --name prod     # generate API key
-m-gpux serve deploy                      # 5-step wizard
+m-gpux serve deploy                      # 6-step wizard
 ```
 
 The wizard walks through:
@@ -66,10 +66,17 @@ The wizard walks through:
 1. **Model** — 11 presets (Qwen, Llama, Gemma, Mistral, DeepSeek, Phi) or custom HuggingFace ID
 2. **GPU** — T4, L4, A10G, L40S, A100, A100-80GB, H100, H200, B200
 3. **Context length** — max sequence length (lower = faster startup)
+3.5. **Engine tuning** — GPU memory utilization, max concurrent sequences, tensor parallel size
 4. **Keep warm** — `0` scales to zero (saves cost), `1+` keeps container(s) always running (no cold start)
 5. **API key** — pick an existing key or auto-create one
 
-After deploy, your endpoint is a drop-in replacement for OpenAI / OpenRouter:
+After deploy, monitor your server with the live dashboard:
+
+```bash
+m-gpux serve dashboard
+```
+
+Your endpoint is a drop-in replacement for OpenAI / OpenRouter:
 
 ```python
 from openai import OpenAI

--- a/m_gpux/__init__.py
+++ b/m_gpux/__init__.py
@@ -1,3 +1,3 @@
 """m_gpux package."""
 
-__version__ = "1.0.11"
+__version__ = "1.0.13"

--- a/m_gpux/commands/serve.py
+++ b/m_gpux/commands/serve.py
@@ -158,7 +158,7 @@ vllm_cache = modal.Volume.from_name("m-gpux-vllm-cache", create_if_missing=True)
 MINUTES = 60
 
 PROXY_CODE = """
-import httpx, json, os, asyncio
+import httpx, json, os, asyncio, time as _time
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import StreamingResponse, Response, JSONResponse
@@ -167,9 +167,64 @@ import uvicorn
 API_KEY = os.environ["MGPUX_API_KEY"]
 VLLM = "http://127.0.0.1:8001"
 
-pool_limits = httpx.Limits(max_connections=200, max_keepalive_connections=100, keepalive_expiry=120)
-timeout = httpx.Timeout(600.0, connect=30.0)
+pool_limits = httpx.Limits(max_connections=300, max_keepalive_connections=150, keepalive_expiry=120)
+timeout = httpx.Timeout(900.0, connect=15.0)
 http_client = None
+
+# ── In-flight request tracking for backpressure ──
+import threading
+_inflight = 0
+_inflight_lock = threading.Lock()
+MAX_INFLIGHT = 150  # reject new requests beyond this to avoid silent hangs
+
+# ── Retry config ──
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF = [1.0, 2.0, 4.0]  # seconds between retries
+
+# ── Metrics tracking ──
+_stats = {
+    "start_time": _time.time(),
+    "total_requests": 0,
+    "total_success": 0,
+    "total_errors_4xx": 0,
+    "total_errors_5xx": 0,
+    "total_retries": 0,
+    "total_tokens_prompt": 0,
+    "total_tokens_completion": 0,
+    "latency_sum": 0.0,
+    "latency_count": 0,
+    "latency_min": float("inf"),
+    "latency_max": 0.0,
+    "latency_recent": [],       # last 50 latencies for p50/p95
+    "peak_inflight": 0,
+    "rejected_429": 0,
+}
+_stats_lock = threading.Lock()
+
+def _record_request(latency, status_code, prompt_tokens=0, completion_tokens=0, retries=0):
+    with _stats_lock:
+        _stats["total_requests"] += 1
+        if 200 <= status_code < 400:
+            _stats["total_success"] += 1
+        elif 400 <= status_code < 500:
+            _stats["total_errors_4xx"] += 1
+        else:
+            _stats["total_errors_5xx"] += 1
+        _stats["total_retries"] += retries
+        _stats["total_tokens_prompt"] += prompt_tokens
+        _stats["total_tokens_completion"] += completion_tokens
+        if latency > 0:
+            _stats["latency_sum"] += latency
+            _stats["latency_count"] += 1
+            if latency < _stats["latency_min"]:
+                _stats["latency_min"] = latency
+            if latency > _stats["latency_max"]:
+                _stats["latency_max"] = latency
+            _stats["latency_recent"].append(latency)
+            if len(_stats["latency_recent"]) > 50:
+                _stats["latency_recent"] = _stats["latency_recent"][-50:]
+        if _inflight > _stats["peak_inflight"]:
+            _stats["peak_inflight"] = _inflight
 
 @asynccontextmanager
 async def lifespan(app):
@@ -183,7 +238,7 @@ app = FastAPI(lifespan=lifespan)
 @app.middleware("http")
 async def auth(request, call_next):
     path = request.url.path
-    if path in ("/health", "/", "/docs", "/openapi.json"):
+    if path in ("/health", "/", "/docs", "/openapi.json", "/stats"):
         return await call_next(request)
     auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -196,39 +251,232 @@ async def auth(request, call_next):
 async def health():
     try:
         r = await http_client.get("/v1/models", timeout=3)
-        return {"status": "ok", "vllm_ready": r.status_code == 200}
+        vllm_ready = r.status_code == 200
     except Exception:
-        return {"status": "ok", "vllm_ready": False}
+        vllm_ready = False
+    resp = {"status": "ok" if vllm_ready else "loading", "vllm_ready": vllm_ready, "inflight_requests": _inflight}
+    return JSONResponse(content=resp, status_code=200)
+
+@app.get("/stats")
+async def stats():
+    import subprocess as _sp
+    with _stats_lock:
+        s = dict(_stats)
+        recent = sorted(s["latency_recent"]) if s["latency_recent"] else []
+    uptime = _time.time() - s["start_time"]
+    avg_latency = s["latency_sum"] / s["latency_count"] if s["latency_count"] else 0
+    p50 = recent[len(recent)//2] if recent else 0
+    p95 = recent[int(len(recent)*0.95)] if recent else 0
+    p99 = recent[int(len(recent)*0.99)] if recent else 0
+    rps = s["total_requests"] / uptime if uptime > 0 else 0
+    # Try to get vLLM model info
+    vllm_info = {}
+    try:
+        r = await http_client.get("/v1/models", timeout=3)
+        if r.status_code == 200:
+            vllm_info = r.json()
+    except Exception:
+        pass
+    # ── GPU metrics via nvidia-smi ──
+    gpus = []
+    try:
+        r = _sp.run(["nvidia-smi",
+            "--query-gpu=name,memory.total,memory.used,memory.free,utilization.gpu,"
+            "utilization.memory,temperature.gpu,power.draw,power.limit",
+            "--format=csv,noheader,nounits"], capture_output=True, text=True, timeout=5)
+        if r.returncode == 0:
+            for i, line in enumerate(r.stdout.strip().splitlines()):
+                p = [x.strip() for x in line.split(",")]
+                if len(p) >= 9:
+                    gpus.append({
+                        "index": i,
+                        "name": p[0],
+                        "vram_total_mib": int(float(p[1])),
+                        "vram_used_mib": int(float(p[2])),
+                        "vram_free_mib": int(float(p[3])),
+                        "gpu_util_pct": int(float(p[4])),
+                        "mem_util_pct": int(float(p[5])),
+                        "temperature_c": int(float(p[6])),
+                        "power_draw_w": round(float(p[7]), 1),
+                        "power_limit_w": round(float(p[8]), 1),
+                    })
+    except Exception:
+        pass
+    # ── CPU metrics ──
+    cpu_info = {}
+    try:
+        with open("/proc/loadavg") as f:
+            parts = f.read().split()
+            cpu_info["load_1m"] = float(parts[0])
+            cpu_info["load_5m"] = float(parts[1])
+            cpu_info["load_15m"] = float(parts[2])
+    except Exception:
+        pass
+    try:
+        with open("/proc/cpuinfo") as f:
+            ci = f.read()
+        cpu_info["cores"] = ci.count("processor" + chr(9) + ":")
+        for ln in ci.splitlines():
+            if ln.startswith("model name"):
+                cpu_info["model"] = ln.split(":", 1)[1].strip()
+                break
+    except Exception:
+        pass
+    # ── RAM metrics ──
+    ram_info = {}
+    try:
+        with open("/proc/meminfo") as f:
+            mi = {}
+            for ln in f:
+                if ":" in ln:
+                    k, v = ln.split(":", 1)
+                    mi[k.strip()] = v.strip()
+        total_kb = int(mi.get("MemTotal", "0 kB").split()[0])
+        avail_kb = int(mi.get("MemAvailable", "0 kB").split()[0])
+        ram_info["total_mb"] = round(total_kb / 1024)
+        ram_info["used_mb"] = round((total_kb - avail_kb) / 1024)
+        ram_info["available_mb"] = round(avail_kb / 1024)
+        ram_info["used_pct"] = round((total_kb - avail_kb) / total_kb * 100, 1) if total_kb else 0
+    except Exception:
+        pass
+    # ── Disk metrics ──
+    disk_info = {}
+    try:
+        st = os.statvfs("/")
+        total_b = st.f_blocks * st.f_frsize
+        free_b = st.f_bavail * st.f_frsize
+        used_b = total_b - free_b
+        disk_info["total_gb"] = round(total_b / (1024**3), 1)
+        disk_info["used_gb"] = round(used_b / (1024**3), 1)
+        disk_info["free_gb"] = round(free_b / (1024**3), 1)
+        disk_info["used_pct"] = round(used_b / total_b * 100, 1) if total_b else 0
+    except Exception:
+        pass
+    return {
+        "uptime_seconds": round(uptime, 1),
+        "inflight_requests": _inflight,
+        "peak_inflight": s["peak_inflight"],
+        "max_inflight_limit": MAX_INFLIGHT,
+        "total_requests": s["total_requests"],
+        "total_success": s["total_success"],
+        "total_errors_4xx": s["total_errors_4xx"],
+        "total_errors_5xx": s["total_errors_5xx"],
+        "total_retries": s["total_retries"],
+        "rejected_429": s["rejected_429"],
+        "requests_per_second": round(rps, 2),
+        "latency_avg_ms": round(avg_latency * 1000, 1),
+        "latency_min_ms": round(s["latency_min"] * 1000, 1) if s["latency_min"] != float("inf") else 0,
+        "latency_max_ms": round(s["latency_max"] * 1000, 1),
+        "latency_p50_ms": round(p50 * 1000, 1),
+        "latency_p95_ms": round(p95 * 1000, 1),
+        "latency_p99_ms": round(p99 * 1000, 1),
+        "tokens_prompt_total": s["total_tokens_prompt"],
+        "tokens_completion_total": s["total_tokens_completion"],
+        "vllm_models": vllm_info,
+        "gpus": gpus,
+        "cpu": cpu_info,
+        "ram": ram_info,
+        "disk": disk_info,
+    }
+
+async def _proxy_with_retry(method, url, content, headers, is_stream):
+    last_exc = None
+    retries_used = 0
+    for attempt in range(RETRY_ATTEMPTS):
+        try:
+            if is_stream:
+                # Client wants streaming — pass through with error handling
+                async def stream_response():
+                    try:
+                        async with http_client.stream(method, url, content=content, headers=headers) as r:
+                            async for chunk in r.aiter_bytes():
+                                yield chunk
+                    except Exception as stream_exc:
+                        # Yield a proper SSE error so client gets notified instead of
+                        # Modal seeing a truncated response (TransferEncodingError)
+                        err_payload = json.dumps({"error": {"message": f"Stream interrupted: {stream_exc}", "type": "server_error"}})
+                        yield f"data: {err_payload}\\n\\ndata: [DONE]\\n\\n".encode()
+                return StreamingResponse(stream_response(), media_type="text/event-stream"), 200, retries_used
+
+            # ── Internal streaming for non-stream requests ──
+            # Stream from vLLM internally to keep connection alive during long inference,
+            # collect all chunks, then return as a normal response.
+            collected = bytearray()
+            status_code = 200
+            content_type = "application/json"
+            async with http_client.stream(method, url, content=content, headers=headers) as r:
+                status_code = r.status_code
+                content_type = r.headers.get("content-type", "application/json")
+                async for chunk in r.aiter_bytes():
+                    collected.extend(chunk)
+
+            # Extract token usage from collected response
+            prompt_tok = 0
+            comp_tok = 0
+            if content_type.startswith("application/json"):
+                try:
+                    rj = json.loads(collected)
+                    usage = rj.get("usage", {})
+                    prompt_tok = usage.get("prompt_tokens", 0)
+                    comp_tok = usage.get("completion_tokens", 0)
+                except Exception:
+                    pass
+            resp = Response(
+                content=bytes(collected),
+                status_code=status_code,
+                media_type=content_type,
+            )
+            return resp, status_code, retries_used, prompt_tok, comp_tok
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError, httpx.ReadError) as exc:
+            last_exc = exc
+            retries_used += 1
+            if attempt < RETRY_ATTEMPTS - 1:
+                await asyncio.sleep(RETRY_BACKOFF[attempt])
+                continue
+        except httpx.PoolTimeout as exc:
+            resp = JSONResponse(status_code=429, content={"error": {"message": f"Server overloaded ({_inflight} requests in flight). Retry after a few seconds.", "type": "rate_limit_error"}, "retry_after": 5})
+            return resp, 429, retries_used, 0, 0
+        except Exception as exc:
+            resp = JSONResponse(status_code=502, content={"error": {"message": f"Backend error: {exc}", "type": "server_error"}})
+            return resp, 502, retries_used, 0, 0
+    resp = JSONResponse(status_code=503, content={"error": {"message": f"vLLM not responding after {RETRY_ATTEMPTS} attempts. Model may still be loading.", "type": "server_error"}, "retry_after": 30})
+    return resp, 503, retries_used, 0, 0
 
 @app.api_route("/v1/{path:path}", methods=["GET","POST"])
 async def proxy(request: Request, path: str):
-    body = await request.body()
-    headers = {k:v for k,v in request.headers.items() if k.lower() not in ("host","authorization","content-length")}
-    is_stream = False
-    if body:
-        try: is_stream = json.loads(body).get("stream", False)
-        except: pass
+    global _inflight
+    # ── Backpressure: reject early if overloaded ──
+    with _inflight_lock:
+        if _inflight >= MAX_INFLIGHT:
+            with _stats_lock:
+                _stats["rejected_429"] += 1
+            _record_request(0, 429)
+            return JSONResponse(status_code=429, content={"error": {"message": f"Too many concurrent requests ({_inflight}/{MAX_INFLIGHT}). Please retry.", "type": "rate_limit_error"}, "retry_after": 5})
+        _inflight += 1
+    t0 = _time.time()
     try:
-        async def stream_response():
-            async with http_client.stream(request.method, f"/v1/{path}", content=body, headers=headers) as r:
-                async for chunk in r.aiter_bytes():
-                    yield chunk
+        body = await request.body()
+        headers = {k:v for k,v in request.headers.items() if k.lower() not in ("host","authorization","content-length")}
+        is_stream = False
+        if body:
+            try: is_stream = json.loads(body).get("stream", False)
+            except: pass
+        result = await _proxy_with_retry(request.method, f"/v1/{path}", body, headers, is_stream)
+        latency = _time.time() - t0
         if is_stream:
-            return StreamingResponse(stream_response(), media_type="text/event-stream")
-        r = await http_client.request(request.method, f"/v1/{path}", content=body, headers=headers)
-        return StreamingResponse(
-            iter([r.content]),
-            status_code=r.status_code,
-            media_type=r.headers.get("content-type", "application/json"),
-        )
-    except (httpx.ConnectError, httpx.TimeoutException):
-        return JSONResponse(status_code=503, content={"error":{"message":"Model is still loading. Try again in a minute.","type":"server_error"}})
-    except Exception as exc:
-        return JSONResponse(status_code=502, content={"error":{"message":f"Backend error: {exc}","type":"server_error"}})
+            resp, status, retries = result[0], result[1], result[2]
+            _record_request(latency, status, retries=retries)
+            return resp
+        resp, status, retries, ptok, ctok = result
+        _record_request(latency, status, prompt_tokens=ptok, completion_tokens=ctok, retries=retries)
+        return resp
+    finally:
+        with _inflight_lock:
+            _inflight -= 1
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info",
-                backlog=2048, limit_concurrency=200, limit_max_requests=None,
+                backlog=2048, limit_concurrency=300, limit_max_requests=None,
                 timeout_keep_alive=120)
 """
 
@@ -253,11 +501,11 @@ def serve():
         "--served-model-name", MODEL_NAME,
         "--host", "0.0.0.0",
         "--port", "8001",
-        "--tensor-parallel-size", "1",
+        "--tensor-parallel-size", "{tensor_parallel}",
         "--max-model-len", "{max_model_len}",
-        "--gpu-memory-utilization", "0.95",
+        "--gpu-memory-utilization", "{gpu_mem_util}",
         "--enable-prefix-caching",
-        "--max-num-seqs", "128",
+        "--max-num-seqs", "{max_num_seqs}",
         "--enable-chunked-prefill",
     ]
     print("[M-GPUX] Starting vLLM on :8001:", " ".join(vllm_cmd))
@@ -355,6 +603,32 @@ def deploy():
     console.print("  [dim]Lower = faster startup + less VRAM. Increase for long inputs.[/dim]")
     max_model_len = Prompt.ask("Max model length (tokens)", default="4096")
 
+    # ── Step 3.5: vLLM Engine Hyperparameters ──
+    console.print("\n[bold cyan]Step 3.5: vLLM Engine Tuning[/bold cyan]  [dim](press Enter for defaults)[/dim]")
+
+    console.print("  [dim]gpu-memory-utilization: fraction of GPU VRAM for KV cache (lower = safer, higher = more throughput)[/dim]")
+    gpu_mem_util = Prompt.ask("  GPU memory utilization", default="0.92")
+    try:
+        gpu_mem_val = float(gpu_mem_util)
+        if not (0.1 <= gpu_mem_val <= 0.99):
+            console.print("  [yellow]Value out of range, using 0.92[/yellow]")
+            gpu_mem_util = "0.92"
+    except ValueError:
+        gpu_mem_util = "0.92"
+
+    console.print("  [dim]max-num-seqs: max concurrent sequences in the engine (higher = more throughput but more VRAM)[/dim]")
+    max_num_seqs = Prompt.ask("  Max concurrent sequences", default="128")
+
+    console.print("  [dim]tensor-parallel-size: number of GPUs for tensor parallelism (1 for single GPU)[/dim]")
+    tensor_parallel = Prompt.ask("  Tensor parallel size", default="1")
+
+    console.print("  [dim]Sampling defaults (applied when client does NOT send these per-request):[/dim]")
+    console.print("  [dim]  top-k: limits token choices to top K candidates (-1 = disabled, 50 = common)[/dim]")
+    console.print("  [dim]  top-p: nucleus sampling probability (0.9-1.0)[/dim]")
+    console.print("  [dim]  Note: clients can always override these per-request in the JSON body.[/dim]")
+
+    console.print(f"\n  [green]Engine config:[/green] mem={gpu_mem_util}, seqs={max_num_seqs}, tp={tensor_parallel}")
+
     # ── Step 4: Keep warm ──
     console.print("\n[bold cyan]Step 4: Keep Warm[/bold cyan]")
     console.print("  [dim]1 = keeps 1 container always running (no cold start, but costs GPU $$).[/dim]")
@@ -404,6 +678,9 @@ def deploy():
         .replace("{gpu_type}", selected_gpu)
         .replace("{api_key}", first_key)
         .replace("{max_model_len}", max_model_len)
+        .replace("{gpu_mem_util}", gpu_mem_util)
+        .replace("{max_num_seqs}", max_num_seqs)
+        .replace("{tensor_parallel}", tensor_parallel)
         .replace("{keep_warm}", str(keep_warm_val))
         .replace("ENV_DICT_PLACEHOLDER", env_dict)
         .replace("VOLUMES_PLACEHOLDER", volumes_dict))
@@ -523,6 +800,287 @@ def logs():
         console.print("\n[dim]Stopped.[/dim]")
     except FileNotFoundError:
         console.print("[red]Modal CLI not found. Install with: pip install modal[/red]")
+
+
+# ─── Dashboard command ────────────────────────────────────────
+
+
+def _fetch_stats(base_url: str):
+    """Fetch /stats and /health from the proxy. Returns (stats_dict, health_dict, error_str)."""
+    import urllib.request
+    stats = None
+    health = None
+    error = None
+    # Fetch /stats
+    try:
+        r = urllib.request.urlopen(f"{base_url}/stats", timeout=5)
+        stats = json.loads(r.read().decode())
+    except Exception as e:
+        error = str(e)
+    # Fetch /health
+    try:
+        r = urllib.request.urlopen(f"{base_url}/health", timeout=5)
+        health = json.loads(r.read().decode())
+    except Exception:
+        if not error:
+            error = "Cannot reach /health"
+    return stats, health, error
+
+
+def _fmt_uptime(seconds: float) -> str:
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    elif m > 0:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def _build_dashboard(stats: dict, health: dict, error: str, base_url: str) -> Panel:
+    """Build a Rich Panel dashboard from stats data."""
+    from rich.text import Text
+    from rich.table import Table as RichTable
+
+    if error and not stats:
+        return Panel(
+            f"[bold red]Cannot connect to server[/bold red]\n\n"
+            f"  URL: {base_url}\n"
+            f"  Error: {error}\n\n"
+            f"[dim]Make sure your LLM API is deployed and the URL is correct.\n"
+            f"Deploy with: m-gpux serve deploy[/dim]",
+            title="[bold red] M-GPUX DASHBOARD — OFFLINE [/bold red]",
+            border_style="red",
+            padding=(1, 2),
+        )
+
+    def _bar(pct, width=25, filled_char="█", empty_char="░"):
+        """Render a colored progress bar string."""
+        pct = max(0, min(100, pct))
+        fill = int(pct / 100 * width)
+        if pct >= 90:
+            color = "red"
+        elif pct >= 70:
+            color = "yellow"
+        elif pct >= 40:
+            color = "green"
+        else:
+            color = "cyan"
+        return f"[{color}]{filled_char * fill}[/{color}][dim]{empty_char * (width - fill)}[/dim] [{color}]{pct:5.1f}%[/{color}]"
+
+    def _temp_bar(temp_c, width=15):
+        """Temperature bar: blue < 50, green < 70, yellow < 85, red >= 85."""
+        pct = min(temp_c / 100 * 100, 100)
+        fill = int(pct / 100 * width)
+        if temp_c >= 85:
+            color = "red"
+        elif temp_c >= 70:
+            color = "yellow"
+        elif temp_c >= 50:
+            color = "green"
+        else:
+            color = "cyan"
+        return f"[{color}]{'▓' * fill}[/{color}][dim]{'░' * (width - fill)}[/dim] [{color}]{temp_c}°C[/{color}]"
+
+    def _latency_bar(ms, max_ms=10000, width=20):
+        """Latency bar scaled to max_ms."""
+        pct = min(ms / max_ms * 100, 100) if max_ms > 0 else 0
+        fill = int(pct / 100 * width)
+        if ms >= 5000:
+            color = "red"
+        elif ms >= 2000:
+            color = "yellow"
+        elif ms >= 500:
+            color = "green"
+        else:
+            color = "cyan"
+        return f"[{color}]{'▇' * fill}[/{color}][dim]{'·' * (width - fill)}[/dim] [{color}]{ms:,.0f}ms[/{color}]"
+
+    # ── Health status ──
+    vllm_ready = health.get("vllm_ready", False) if health else False
+    if vllm_ready:
+        status_icon = "[bold green]● ONLINE[/bold green]"
+        status_color = "green"
+    else:
+        status_icon = "[bold yellow]◐ LOADING[/bold yellow]"
+        status_color = "yellow"
+
+    uptime = _fmt_uptime(stats.get("uptime_seconds", 0))
+    inflight = stats.get("inflight_requests", 0)
+    peak = stats.get("peak_inflight", 0)
+    limit = stats.get("max_inflight_limit", 150)
+
+    # ── Model info ──
+    model_name = "—"
+    vllm_models = stats.get("vllm_models", {})
+    if vllm_models and "data" in vllm_models:
+        models_list = vllm_models["data"]
+        if models_list:
+            model_name = models_list[0].get("id", "—")
+
+    # ── Request counters ──
+    total = stats.get("total_requests", 0)
+    success = stats.get("total_success", 0)
+    err_4xx = stats.get("total_errors_4xx", 0)
+    err_5xx = stats.get("total_errors_5xx", 0)
+    retries = stats.get("total_retries", 0)
+    rejected = stats.get("rejected_429", 0)
+    rps = stats.get("requests_per_second", 0)
+    success_rate = (success / total * 100) if total > 0 else 100.0
+
+    # ── Latency ──
+    avg_ms = stats.get("latency_avg_ms", 0)
+    min_ms = stats.get("latency_min_ms", 0)
+    max_ms = stats.get("latency_max_ms", 0)
+    p50 = stats.get("latency_p50_ms", 0)
+    p95 = stats.get("latency_p95_ms", 0)
+    p99 = stats.get("latency_p99_ms", 0)
+    lat_scale = max(max_ms, 1000)  # scale bars to the max observed, min 1000ms
+
+    # ── Tokens ──
+    tok_prompt = stats.get("tokens_prompt_total", 0)
+    tok_comp = stats.get("tokens_completion_total", 0)
+    tok_total = tok_prompt + tok_comp
+
+    # ── GPU data ──
+    gpus = stats.get("gpus", [])
+    cpu = stats.get("cpu", {})
+    ram = stats.get("ram", {})
+    disk = stats.get("disk", {})
+
+    lines = []
+
+    # ━━ HEADER ━━
+    lines.append(f"  {status_icon}  │  Uptime: [bold]{uptime}[/bold]  │  Model: [cyan]{model_name}[/cyan]  │  [bold]{rps:.1f}[/bold] req/s")
+    lines.append(f"  {'━' * 72}")
+
+    # ━━ GPU SECTION ━━
+    if gpus:
+        lines.append("")
+        lines.append(f"  [bold magenta]🔲 GPU[/bold magenta]")
+        for g in gpus:
+            vram_total = g.get("vram_total_mib", 1)
+            vram_used = g.get("vram_used_mib", 0)
+            vram_pct = vram_used / vram_total * 100 if vram_total else 0
+            gpu_util = g.get("gpu_util_pct", 0)
+            mem_util = g.get("mem_util_pct", 0)
+            temp = g.get("temperature_c", 0)
+            pwr_draw = g.get("power_draw_w", 0)
+            pwr_limit = g.get("power_limit_w", 1)
+            pwr_pct = pwr_draw / pwr_limit * 100 if pwr_limit else 0
+            gpu_name = g.get("name", "GPU")
+
+            lines.append(f"  [bold]{gpu_name}[/bold] (GPU {g.get('index', 0)})")
+            lines.append(f"    VRAM     {_bar(vram_pct)}  [dim]{vram_used:,} / {vram_total:,} MiB[/dim]")
+            lines.append(f"    Compute  {_bar(gpu_util)}")
+            lines.append(f"    Mem BW   {_bar(mem_util)}")
+            lines.append(f"    Temp     {_temp_bar(temp)}")
+            lines.append(f"    Power    {_bar(pwr_pct, width=15)}  [dim]{pwr_draw:.0f} / {pwr_limit:.0f} W[/dim]")
+    else:
+        lines.append("")
+        lines.append(f"  [bold magenta]🔲 GPU[/bold magenta]  [dim](no data — container may be cold)[/dim]")
+
+    # ━━ CPU / RAM / DISK ━━
+    lines.append("")
+    lines.append(f"  [bold blue]💻 System[/bold blue]")
+    if cpu:
+        cpu_model = cpu.get("model", "—")
+        cores = cpu.get("cores", "?")
+        load_1m = cpu.get("load_1m", 0)
+        load_pct = load_1m / max(int(cores) if str(cores).isdigit() else 1, 1) * 100
+        lines.append(f"    CPU      {_bar(min(load_pct, 100))}  [dim]{cpu_model} ({cores} cores) load: {load_1m:.1f}[/dim]")
+    else:
+        lines.append(f"    CPU      [dim](no data)[/dim]")
+
+    if ram:
+        ram_pct = ram.get("used_pct", 0)
+        ram_used = ram.get("used_mb", 0)
+        ram_total = ram.get("total_mb", 0)
+        lines.append(f"    RAM      {_bar(ram_pct)}  [dim]{ram_used:,} / {ram_total:,} MB[/dim]")
+    else:
+        lines.append(f"    RAM      [dim](no data)[/dim]")
+
+    if disk:
+        disk_pct = disk.get("used_pct", 0)
+        disk_used = disk.get("used_gb", 0)
+        disk_total = disk.get("total_gb", 0)
+        lines.append(f"    Disk     {_bar(disk_pct)}  [dim]{disk_used:.1f} / {disk_total:.1f} GB[/dim]")
+    else:
+        lines.append(f"    Disk     [dim](no data)[/dim]")
+
+    # ━━ TRAFFIC ━━
+    lines.append("")
+    lines.append(f"  [bold green]📡 Traffic[/bold green]")
+    inflight_pct = inflight / max(limit, 1) * 100
+    lines.append(f"    Active   {_bar(inflight_pct)}  [bold]{inflight}[/bold] / {limit}  (peak: {peak})")
+    sr_color = "green" if success_rate >= 99 else ("yellow" if success_rate >= 95 else "red")
+    lines.append(f"    Success  {_bar(success_rate, width=25, filled_char='▓')}  [dim]{success:,} / {total:,}[/dim]")
+    lines.append(f"    Errors   4xx: [yellow]{err_4xx:,}[/yellow]  │  5xx: [red]{err_5xx:,}[/red]  │  429 rejected: [red]{rejected:,}[/red]  │  retries: [yellow]{retries:,}[/yellow]")
+
+    # ━━ LATENCY ━━
+    lines.append("")
+    lines.append(f"  [bold yellow]⏱ Latency[/bold yellow]  [dim](scale: 0 — {lat_scale:,.0f}ms)[/dim]")
+    lines.append(f"    Avg      {_latency_bar(avg_ms, lat_scale)}")
+    lines.append(f"    P50      {_latency_bar(p50, lat_scale)}")
+    lines.append(f"    P95      {_latency_bar(p95, lat_scale)}")
+    lines.append(f"    P99      {_latency_bar(p99, lat_scale)}")
+    lines.append(f"    Min      {_latency_bar(min_ms, lat_scale)}")
+    lines.append(f"    Max      {_latency_bar(max_ms, lat_scale)}")
+
+    # ━━ TOKENS ━━
+    lines.append("")
+    lines.append(f"  [bold cyan]🔤 Tokens[/bold cyan]")
+    if tok_total > 0:
+        prompt_pct = tok_prompt / tok_total * 100
+        lines.append(f"    Prompt   {_bar(prompt_pct, width=20, filled_char='▪', empty_char='·')}  [cyan]{tok_prompt:,}[/cyan]")
+        lines.append(f"    Complet  {_bar(100 - prompt_pct, width=20, filled_char='▪', empty_char='·')}  [cyan]{tok_comp:,}[/cyan]")
+        lines.append(f"    Total    [bold]{tok_total:,}[/bold]")
+    else:
+        lines.append(f"    [dim]No tokens processed yet[/dim]")
+
+    lines.append("")
+    lines.append(f"  [dim]{'━' * 72}[/dim]")
+    lines.append(f"  [dim]Polling {base_url}/stats • Ctrl+C to exit[/dim]")
+
+    content = "\n".join(lines)
+    now_str = datetime.now().strftime("%H:%M:%S")
+    return Panel(
+        content,
+        title=f"[bold cyan] ⚡ M-GPUX LLM Dashboard [/bold cyan]  [dim]{now_str}[/dim]",
+        border_style=status_color,
+        padding=(1, 0),
+    )
+
+
+@app.command("dashboard")
+def dashboard(
+    url: str = typer.Option(None, "--url", "-u", help="Base URL of the deployed API"),
+    interval: float = typer.Option(3.0, "--interval", "-i", help="Refresh interval in seconds"),
+):
+    """Live terminal dashboard showing LLM API metrics, latency, and traffic."""
+    from rich.live import Live
+
+    if not url:
+        profiles = _load_profiles_for_url()
+        if profiles:
+            url = profiles[0]
+            console.print(f"  [dim]Auto-detected URL: {url}[/dim]")
+        else:
+            url = Prompt.ask("Enter your deployment base URL")
+
+    url = url.rstrip("/")
+    console.print(f"[cyan]Starting dashboard for {url} (refresh every {interval}s)...[/cyan]\n")
+
+    try:
+        with Live(console=console, refresh_per_second=1, screen=False) as live:
+            while True:
+                stats, health, error = _fetch_stats(url)
+                panel = _build_dashboard(stats, health, error, url)
+                live.update(panel)
+                time.sleep(interval)
+    except KeyboardInterrupt:
+        console.print("\n[dim]Dashboard stopped.[/dim]")
 
 
 # ─── Stop command ─────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "m-gpux"
-version = "1.0.12"
+version = "1.0.13"
 description = "Professional CLI toolkit for Modal GPU workflows, account management, and billing visibility"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Add 'm-gpux serve dashboard' with Rich Live terminal UI
  - GPU metrics: VRAM, compute, mem bandwidth, temp, power (progress bars)
  - System metrics: CPU load, RAM, disk usage (progress bars)
  - Traffic: in-flight capacity bar, success rate, error counts
  - Latency: avg/P50/P95/P99/min/max with scaled bars
  - Tokens: prompt/completion ratio bars
- Add /stats endpoint to proxy for real-time metrics collection
- Proxy resilience improvements:
  - Retry with backoff (3 attempts, 1s/2s/4s) on connection errors
  - Backpressure: 429 rejection when >150 concurrent requests
  - Internal streaming for non-stream requests (prevents timeout on long inference)
  - Stream error recovery (SSE error event instead of TransferEncodingError)
  - Added RemoteProtocolError + ReadError to retry list
- Deploy wizard Step 3.5: configurable vLLM hyperparameters
  - gpu-memory-utilization (default 0.92)
  - max-num-seqs (default 128)
  - tensor-parallel-size (default 1)
- Health endpoint always returns 200 (prevents Modal container kill during model load)
- Proxy timeout increased to 900s for large context inference
- Fix SyntaxError in proxy code (split/tab escaping in template string)
- Update README, docs/commands.md, docs/index.md, docs/architecture.md